### PR TITLE
Fix TabBar active tab not respecting custom streamlit theme

### DIFF
--- a/extra_streamlit_components/BouncingImage/frontend/public/bootstrap.min.css
+++ b/extra_streamlit_components/BouncingImage/frontend/public/bootstrap.min.css
@@ -5,9 +5,6 @@
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */
 :root {
-  --stremlit-primary-color: #f63366;
-  --stremlit-primary-color-opaque: #f6336650;
-  --stremlit-text-color: #262730;
   --blue: #007bff;
   --indigo: #6610f2;
   --purple: #6f42c1;
@@ -346,8 +343,8 @@ h6 {
 
 .menu-item.active {
   border: 1px green solid;
-  border-color: var(--stremlit-primary-color);
-  color: var(--stremlit-primary-color);
+  border-color: var(--primary-color);
+  color: var(--primary-color);
   fill-opacity: 0.5;
   font-weight: 500;
 }

--- a/extra_streamlit_components/StepperBar/frontend/public/bootstrap.min.css
+++ b/extra_streamlit_components/StepperBar/frontend/public/bootstrap.min.css
@@ -5,9 +5,6 @@
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */
 :root {
-  --stremlit-primary-color: #f63366;
-  --stremlit-primary-color-opaque: #f6336650;
-  --stremlit-text-color: #262730;
   --blue: #007bff;
   --indigo: #6610f2;
   --purple: #6f42c1;
@@ -346,8 +343,8 @@ h6 {
 
 .menu-item.active {
   border: 1px green solid;
-  border-color: var(--stremlit-primary-color);
-  color: var(--stremlit-primary-color);
+  border-color: var(--primary-color);
+  color: var(--primary-color);
   fill-opacity: 0.5;
   font-weight: 500;
 }

--- a/extra_streamlit_components/TabBar/frontend/public/bootstrap.min.css
+++ b/extra_streamlit_components/TabBar/frontend/public/bootstrap.min.css
@@ -5,9 +5,6 @@
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
  */
 :root {
-  --stremlit-primary-color: #f63366;
-  --stremlit-primary-color-opaque: #f6336650;
-  --stremlit-text-color: #262730;
   --blue: #007bff;
   --indigo: #6610f2;
   --purple: #6f42c1;
@@ -346,8 +343,8 @@ h6 {
 
 .menu-item.active {
   border: 1px green solid;
-  border-color: var(--stremlit-primary-color);
-  color: var(--stremlit-primary-color);
+  border-color: var(--primary-color);
+  color: var(--primary-color);
   fill-opacity: 0.5;
   font-weight: 500;
 }


### PR DESCRIPTION
The `TabBar` component only partially respects the global streamlit theme.

As seen in the image below, the `<hr>` is blue (matching the custom streamlit theme) while the active tab still shows as the default pink/red.

**Before:**
![image](https://user-images.githubusercontent.com/47728752/208593961-f02768b0-d741-49bd-a531-a0266b8adc81.png)

This PR updates the active tab styling to correctly make use of the custom streamlit theme via the `--primary-color` css variable.

**After:**

![image](https://user-images.githubusercontent.com/47728752/208595007-7280b22d-d6bb-4208-9c6a-fe855e621937.png)

