### PR TITLE
fix: make rerun optional for router

### DIFF
--- a/extra_streamlit_components/Router/__init__.py
+++ b/extra_streamlit_components/Router/__init__.py
@@ -65,10 +65,11 @@ class Router:
         route = self.get_nav_query_param()
         return route
 
-    def route(self, new_route):
+    def route(self, new_route, do_rerun=True):
         if new_route[0] != "/":
             new_route = "/" + new_route
         st.session_state['stx_router_route'] = new_route
         st.experimental_set_query_params(nav=new_route)
         time.sleep(0.1)  # Needed for URL param refresh
-        st.experimental_rerun()
+        if do_rerun:
+            st.experimental_rerun()


### PR DESCRIPTION
There is an issue where StreamLit errors about how rerunning is a no-op, and it shows it forcibly on the frontend. To fix this, I want to make the `experimental_set_query_params` call optional in the `route()` method optional.

Note: this will *not* change the default routing behavior, it will just give users an option to suppress that no-op error.