### PR TITLE
Reduced number of re-rendering - only renders when change to `method` is recognised.

### DIFF
--- a/extra_streamlit_components/CookieManager/__init__.py
+++ b/extra_streamlit_components/CookieManager/__init__.py
@@ -78,8 +78,8 @@ class CookieManager:
         if cookie is None or cookie == "":
             return
         try:
-            did_add = self.cookie_manager(method="delete", cookie=cookie, key=key, default=False)
-            return did_add
+            did_del = self.cookie_manager(method="delete", cookie=cookie, key=key, default=False)
+            return did_del
         except:
             return False
 

--- a/extra_streamlit_components/CookieManager/__init__.py
+++ b/extra_streamlit_components/CookieManager/__init__.py
@@ -28,7 +28,7 @@ class CookieManager:
 
     def set(
         self,
-        return_cookie,
+        return_cookie=False,
         cookie: str,
         val: Union[str, int, float, bool],
         key: str = "set",
@@ -75,7 +75,7 @@ class CookieManager:
         except:
             return False
 
-    def delete(self, return_cookie, cookie, key="delete"):
+    def delete(self, return_cookie=False, cookie, key="delete"):
         if cookie is None or cookie == "":
             return
         try:

--- a/extra_streamlit_components/CookieManager/__init__.py
+++ b/extra_streamlit_components/CookieManager/__init__.py
@@ -28,7 +28,7 @@ class CookieManager:
 
     def set(
         self,
-        return_cookie_set,
+        return_cookie,
         cookie: str,
         val: Union[str, int, float, bool],
         key: str = "set",
@@ -70,16 +70,16 @@ class CookieManager:
         # Remove None's
         options = {k: v for k, v in options.items() if v is not None}
         try:
-            did_add = self.cookie_manager(method="set", return_cookie_set=return_cookie_set, cookie=cookie, val=val, options=options, key=key, default=False) 
+            did_add = self.cookie_manager(method="set", return_cookie=return_cookie, cookie=cookie, val=val, options=options, key=key, default=False) 
             return did_add
         except:
             return False
 
-    def delete(self, return_cookie_set, cookie, key="delete"):
+    def delete(self, return_cookie, cookie, key="delete"):
         if cookie is None or cookie == "":
             return
         try:
-            did_del = self.cookie_manager(method="delete", return_cookie_set=return_cookie_set, cookie=cookie, key=key, default=False)
+            did_del = self.cookie_manager(method="delete", return_cookie=return_cookie, cookie=cookie, key=key, default=False)
             return did_del
         except:
             return False

--- a/extra_streamlit_components/CookieManager/__init__.py
+++ b/extra_streamlit_components/CookieManager/__init__.py
@@ -14,12 +14,17 @@ else:
 
 
 class CookieManager:
-    def __init__(self, key="init"):
+    def __init__(self):
         self.cookie_manager = _component_func
-        self.cookies = self.cookie_manager(method="getAll", key=key, default={})
-
-    def get(self, cookie: str):
-        return self.cookies.get(cookie)
+    
+    def get(self, cookie: str, key:str="get"):
+        if cookie == "" or cookie == None:
+            return
+        try:
+            value = self.cookie_manager(method="get", cookie=cookie, key=key)
+            return value
+        except:
+            return False
 
     def set(
         self,
@@ -54,7 +59,7 @@ class CookieManager:
 
         expires = expires_at.isoformat()
         options = {
-            "path": path,
+            "path": path, 
             "expires": expires,
             "maxAge": max_age,
             "domain": domain,
@@ -63,17 +68,21 @@ class CookieManager:
         }
         # Remove None's
         options = {k: v for k, v in options.items() if v is not None}
-        did_add = self.cookie_manager(method="set", cookie=cookie, value=val, options=options, key=key, default=False)
-        if did_add:
-            self.cookies[cookie] = val
+        try:
+            did_add = self.cookie_manager(method="set", cookie=cookie, val=val, options=options, key=key, default=False) 
+            return did_add
+        except:
+            return False
 
     def delete(self, cookie, key="delete"):
         if cookie is None or cookie == "":
             return
-        did_add = self.cookie_manager(method="delete", cookie=cookie, key=key, default=False)
-        if did_add:
-            del self.cookies[cookie]
+        try:
+            did_add = self.cookie_manager(method="delete", cookie=cookie, key=key, default=False)
+            return did_add
+        except:
+            return False
 
     def get_all(self, key="get_all"):
-        self.cookies = self.cookie_manager(method="getAll", key=key, default={})
-        return self.cookies
+        cookies = self.cookie_manager(method="getAll", key=key, default={})
+        return cookies

--- a/extra_streamlit_components/CookieManager/__init__.py
+++ b/extra_streamlit_components/CookieManager/__init__.py
@@ -28,6 +28,7 @@ class CookieManager:
 
     def set(
         self,
+        return_cookie_set,
         cookie: str,
         val: Union[str, int, float, bool],
         key: str = "set",
@@ -69,16 +70,16 @@ class CookieManager:
         # Remove None's
         options = {k: v for k, v in options.items() if v is not None}
         try:
-            did_add = self.cookie_manager(method="set", cookie=cookie, val=val, options=options, key=key, default=False) 
+            did_add = self.cookie_manager(method="set", return_cookie_set=return_cookie_set, cookie=cookie, val=val, options=options, key=key, default=False) 
             return did_add
         except:
             return False
 
-    def delete(self, cookie, key="delete"):
+    def delete(self, return_cookie_set, cookie, key="delete"):
         if cookie is None or cookie == "":
             return
         try:
-            did_del = self.cookie_manager(method="delete", cookie=cookie, key=key, default=False)
+            did_del = self.cookie_manager(method="delete", return_cookie_set=return_cookie_set, cookie=cookie, key=key, default=False)
             return did_del
         except:
             return False

--- a/extra_streamlit_components/CookieManager/frontend/src/CookieManager.jsx
+++ b/extra_streamlit_components/CookieManager/frontend/src/CookieManager.jsx
@@ -13,6 +13,7 @@ const CookieManager:React.FC<ComponentProps> = (props) => {
   const cookies = new Cookies()
 
   const { args } = props
+  const return_cookie_set = args["return_cookie_set"] 
 
   const set = (cookie, val, options) => {
     const converted_options = {
@@ -50,6 +51,10 @@ const CookieManager:React.FC<ComponentProps> = (props) => {
     switch(method) {
       case "set":
         output = set(cookie, val, options)
+        if (return_cookie_set){ 
+          Streamlit.setComponentValue(output)
+          Streamlit.setComponentReady()
+          }
         break
       case "get":
         output = getCookie(cookie) 
@@ -63,6 +68,10 @@ const CookieManager:React.FC<ComponentProps> = (props) => {
         break 
       case "delete":
         output = deleteCookie(cookie)
+        if (return_cookie_set){ 
+          Streamlit.setComponentValue(output)
+          Streamlit.setComponentReady()
+          }
       default:
           break
   }}, [method, cookie, val, options]) 

--- a/extra_streamlit_components/CookieManager/frontend/src/CookieManager.jsx
+++ b/extra_streamlit_components/CookieManager/frontend/src/CookieManager.jsx
@@ -44,7 +44,7 @@ const CookieManager:React.FC<ComponentProps> = (props) => {
   const options = args["options"]
   
   
-  useEffect(() => {
+  useMemo(() => {
     let output = null
     
     switch(method) {

--- a/extra_streamlit_components/CookieManager/frontend/src/CookieManager.jsx
+++ b/extra_streamlit_components/CookieManager/frontend/src/CookieManager.jsx
@@ -1,22 +1,26 @@
 import {
   Streamlit,
-  ComponentProps,
+  StreamlitComponentBase,
   withStreamlitConnection,
+  ComponentProps
 } from "streamlit-component-lib"
 import React, { useEffect } from "react"
-
 import Cookies from "universal-cookie"
 
-let last_output = null
-const cookies = new Cookies()
 
-const CookieManager = (props: ComponentProps) => {
-  const setCookie = (cookie, value, options) => {
+const CookieManager:React.FC<ComponentProps> = (props) => {
+
+  const cookies = new Cookies()
+
+  const { args } = props
+
+  const set = (cookie, val, options) => {
     const converted_options = {
       expires: new Date(options.expires),
     }
     options = { ...options, ...converted_options }
-    cookies.set(cookie, value, options)
+ 
+    cookies.set(cookie, val, options)
     return true
   }
 
@@ -25,49 +29,48 @@ const CookieManager = (props: ComponentProps) => {
     return value
   }
 
-  const deleteCookie = (cookie) => {
-    cookies.remove(cookie, { path: "/", samesite: "strict" })
-    return true
-  }
-
   const getAllCookies = () => {
     return cookies.getAll()
   }
 
-  const { args } = props
+  const deleteCookie = (cookie) => { 
+    cookies.remove(cookie)
+    return true
+  }
 
   const method = args["method"]
-  const cookie = args["cookie"]
-  const value = args["value"]
-  const options = args["options"]
+  
+  
+  useEffect(() => {
+    let output = null
+    const cookie = args["cookie"]
+    const val = args["val"]  
+    const options = args["options"]
 
-  let output = null
+    switch(method) {
+      case "set":
+        output = set(cookie, val, options)
+        break
+      case "get":
+        output = getCookie(cookie) 
+        Streamlit.setComponentValue(output)
+        Streamlit.setComponentReady()
+        break
+      case "getAll":
+        output = getAllCookies()
+        Streamlit.setComponentValue(output)
+        Streamlit.setComponentReady() 
+        break 
+      case "delete":
+        output = deleteCookie(cookie)
+      default:
+          break
+  }}, [method]) 
 
-  switch (method) {
-    case "set":
-      output = setCookie(cookie, value, options)
-      break
-    case "get":
-      output = getCookie(cookie)
-      break
-    case "getAll":
-      output = getAllCookies()
-      break
-    case "delete":
-      output = deleteCookie(cookie)
-      break
-    default:
-      break
-  }
 
-  if (output && JSON.stringify(last_output) != JSON.stringify(output)) {
-    last_output = output
-    Streamlit.setComponentValue(output)
-    Streamlit.setComponentReady()
-  }
-
-  useEffect(() => Streamlit.setFrameHeight())
-  return <div></div>
+  return (      
+        <div style={{display:"none"}}></div>
+  )
 }
 
 export default withStreamlitConnection(CookieManager)

--- a/extra_streamlit_components/CookieManager/frontend/src/CookieManager.jsx
+++ b/extra_streamlit_components/CookieManager/frontend/src/CookieManager.jsx
@@ -39,14 +39,14 @@ const CookieManager:React.FC<ComponentProps> = (props) => {
   }
 
   const method = args["method"]
+  const cookie = args["cookie"]
+  const val = args["val"]  
+  const options = args["options"]
   
   
   useEffect(() => {
     let output = null
-    const cookie = args["cookie"]
-    const val = args["val"]  
-    const options = args["options"]
-
+    
     switch(method) {
       case "set":
         output = set(cookie, val, options)
@@ -65,7 +65,7 @@ const CookieManager:React.FC<ComponentProps> = (props) => {
         output = deleteCookie(cookie)
       default:
           break
-  }}, [method]) 
+  }}, [method, cookie, val, options]) 
 
 
   return (      

--- a/extra_streamlit_components/CookieManager/frontend/src/CookieManager.jsx
+++ b/extra_streamlit_components/CookieManager/frontend/src/CookieManager.jsx
@@ -13,7 +13,6 @@ const CookieManager:React.FC<ComponentProps> = (props) => {
   const cookies = new Cookies()
 
   const { args } = props
-  const return_cookie_set = args["return_cookie_set"] 
 
   const set = (cookie, val, options) => {
     const converted_options = {
@@ -43,6 +42,7 @@ const CookieManager:React.FC<ComponentProps> = (props) => {
   const cookie = args["cookie"]
   const val = args["val"]  
   const options = args["options"]
+  const return_cookie = args["return_cookie"] 
   
   
   useMemo(() => {
@@ -51,7 +51,7 @@ const CookieManager:React.FC<ComponentProps> = (props) => {
     switch(method) {
       case "set":
         output = set(cookie, val, options)
-        if (return_cookie_set){ 
+        if (return_cookie){ 
           Streamlit.setComponentValue(output)
           Streamlit.setComponentReady()
           }
@@ -68,7 +68,7 @@ const CookieManager:React.FC<ComponentProps> = (props) => {
         break 
       case "delete":
         output = deleteCookie(cookie)
-        if (return_cookie_set){ 
+        if (return_cookie){ 
           Streamlit.setComponentValue(output)
           Streamlit.setComponentReady()
           }


### PR DESCRIPTION
I love the cookies part of this package but thought the performance was far too poor to be deployed for production. I then adopted the methodology for my package that saves data to local storage ([view here](https://github.com/Socvest/streamlit-local-storage/tree/main)). Only renders when there is a change to the `method` variable which I implemented in the src file. 

This video shows the drastic reduction in the number of re-renders which improves component performance. 



![streamlit-example-2023-09-29-01-09-44](https://github.com/Mohamed-512/Extra-Streamlit-Components/assets/82335390/154d4b79-45f1-42a7-8433-3a3f7bb0bc3f)


I also found that the double rendering was derived from calling the `get_all()` method when the class is initialised. This causes far too many rendering and removing this caused component to render once (only when called - when the app re-reruns but once not multiple time).